### PR TITLE
Separate server installation from acl configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Debian and Ubuntu are planned but currently not supported.
 * `node.ca_openldap.rootdn` - RootDN, relative to `node.ca_openldap.basedn` (default: `"cn=Manager"`)
 * `node.ca_openldap.rootpassword` - Root Password, it is strongly recommended to modify the default value (default: `"pa$$word"`) 
 * `node.ca_openldap.ldap_log_level` - Log level - see [Slapd config] (http://www.openldap.org/doc/admin24/slapdconfig.html) for explanation of supported values (default: `"-1"`)
-* `node.ca_openldap.acls` - ACLs, this is a ruby Array of the ACL to create, each line must comply with the OpenLDAP ACL syntax (default allows to read any attributes (except password) from any authenticated users and to write any attributes that belongs to the current user)
 * `node.ca_openldap.default_ports.ldap` - Port of the 'clear' LDAP socket, used only when ca\_openldap.tls.enable is to `:no` or `:yes`
 * `node.ca_openldap.defaut_ports.ldaps` - Port of the TLS socket, used only when ca\_openldap.tls.enable is set to `:yes` or `:exclusive`
 * `node.ca_openldap.tls.enable` - Configure the TLS access support, accepted values are (default `:exclusive`): 
@@ -53,6 +52,9 @@ Debian and Ubuntu are planned but currently not supported.
     * `node.ca_openldap.tls.cert_file`: points to the Server certificate (/etc/pki/tls/certs/\<fqdn\>.pem for RHEL).
     * `node.ca_openldap.tls.cacert_path + "/" + cacert_hash + ".0"`: points to the CA certificate chain (/etc/pki/tls/certs/\<_hostname_\>-bundle.crt for RHEL), cacert_hash is the X509 hash of the CA certificate file.
 Additionally the key file (/etc/pki/tls/private/\<_fqdn_\>.key) is copied to `node.ca_openldap.tls.key_file`.
+
+### ACL attributes
+* `node.ca_openldap.acls` - ACLs, this is a ruby Array of the ACL to create, each line must comply with the OpenLDAP ACL syntax (default allows to read any attributes (except password) from any authenticated users and to write any attributes that belongs to the current user)
 
 ### PPolicy attributes
 * `node.ca_openldap.ppolicy_default_config_dn` - DN where the default ppolicy configuration is stored, relatively to the `node.ca_openldap.basedn` (default: `"cn=passwordDefault,ou=policies"`).
@@ -83,13 +85,17 @@ This recipe performs the following actions:
 * enable if requested the TLS support (see dedicated section below)
 * set the base directory for the BDB files
 * set the slapd log level
-* configure ACLs 
+
+### acl
+
+Configure Access Control List for a given server. Uses `node.ca_openldap.acls` as a list of ACLs to add.
 
 ### client
 
 Install the OpenLDAP client packages and configure access to an OpenLDAP Server.
 
 This recipe depends on the common attributes and the `node.ca_openldap.use_existing_certs_and_key` and `node.ca_openldap.tls.cacert_path`attributes.
+
 
 ### dit
 

--- a/recipes/acl.rb
+++ b/recipes/acl.rb
@@ -1,0 +1,45 @@
+#
+# Cookbook Name:: ca_openldap
+# Recipe File:: client
+#
+# Copyright 2013, Christophe Arguel <christophe.arguel@free.fr>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Enable slapd service and stop it in order to complete its configuration
+service "slapd" do
+  action [:enable, :stop]
+end
+
+# Configure the base DN, the root DN and its password
+my_root_dn = build_rootdn
+ruby_block "acl_config" do
+  block do
+    slapd_conf_file = '/etc/openldap/slapd.d/cn=config/olcDatabase={2}bdb.ldif'
+    #configure acl
+    f = Chef::Util::FileEdit.new(slapd_conf_file)
+    f.search_file_delete_line(/olcAccess:/)
+    index = 0
+    acls = node.ca_openldap.acls.inject("") do |acum, acl|
+      acum << "olcAccess: {#{index}}#{acl}\n"
+      index+= 1
+      acum
+    end
+    f.insert_line_after_match(/olcLogLevel:/, acls)
+
+    f.write_file
+  end
+  action :create
+  notifies :start, "service[slapd]", :immediately
+end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -113,16 +113,8 @@ ruby_block "bdb_config" do
     f.search_file_delete_line(/olcLogLevel:/)
     f.insert_line_after_match(/olcRootPW:/, "olcLogLevel: #{node.ca_openldap.ldap_log_level}")
     
-    #configure acl
+    #delete acl lines, will be added again in recipe acl
     f.search_file_delete_line(/olcAccess:/)
-    index = 0
-    acls = node.ca_openldap.acls.inject("") do |acum, acl|
-      acum << "olcAccess: {#{index}}#{acl}\n"
-      index+= 1
-      acum
-    end
-    f.insert_line_after_match(/olcLogLevel:/, acls)
-
     f.write_file
   end
   action :create


### PR DESCRIPTION
An ACL may give access to an attribute that is defined by a ppolicy. For instance, you may decide that a specific user should have a reading right to attribute pwdAccountLockedTime, to check wether an account has been locked.

When configuring ACL right after the server installation, the password policy isn't set yet. Starting the slapd service with ACL `"to (...) attrs=uid,pwdAccountLockedTime by (...) read` therefore finds an invalid attribute `pwdAccountLockedTime ` in ACLs, exits in error, aborts the chef-client, which prevents chef from setting the pasword policy defining those invalid attributes.

This pull requests does the following changes:
* changes `server.rb` recipe: ACLs are not added in `olcDatabase={2}bdb.ldif` in this recipe. Existing lines are deleted to prevent the previous error from happening again (feel free to undo that part if necessary)
* adds `acl.rb` recipe to configure ACLs.
* edits README.md file to document the changes

Cookbook users should now call explicitly `ca_openldap::acl` to configure ACLs.